### PR TITLE
Pkg enhancements

### DIFF
--- a/server/api/datasource/fieldtypes.js
+++ b/server/api/datasource/fieldtypes.js
@@ -134,7 +134,9 @@ var bootstrapTypeMap = {
   'object':Mixed,
   'attachment':Mixed,
   'password':Mixed,
-  'image':Mixed
+  'image':Mixed,
+  'datetime':Date,
+  'url':String
 };
 
 

--- a/server/api/datasource/packaging/fs_sync.js
+++ b/server/api/datasource/packaging/fs_sync.js
@@ -161,7 +161,7 @@ exports.packageFromFs = function(srcDir) {
     }
     
     
-    return PkgService.importObject('BusinessObjectPackage', bopObj).then(function() {
+    return PkgService.importObject('BusinessObjectPackage', bopObj, false).then(function() {
         
         var promiseChain = Q(true);
         
@@ -251,7 +251,7 @@ function importClassDir(srcDir, className) {
         
         //Import the list
         _.forEach(jsonObjects, function(obj) {
-            promiseChain = promiseChain.then(PkgService.importObject.bind(null, className, obj));
+            promiseChain = promiseChain.then(PkgService.importObject.bind(null, className, obj, false));
         });
         
 	}

--- a/server/api/datasource/packaging/index.js
+++ b/server/api/datasource/packaging/index.js
@@ -379,6 +379,7 @@ exports.importObject = function(className, obj, packageRef) {
     return db[className].findOne({_id:boId}).then(function(modelObj) {
         
         if(packageRef && modelObj && db.PackageConflict) {
+            
             //Check validity of stepping from current version -> update version
             var updateVer = obj.__ver;
             
@@ -387,8 +388,14 @@ exports.importObject = function(className, obj, packageRef) {
             var versionRel = pkgVer.relationshipTo(currentVer);
             
             if(versionRel.same) {
-                //No need for any more work
-                return;
+                //If they're the same
+                if(className === 'BusinessObjectDef') {
+                    //Special case: always refresh BOD's w/ system datalayer
+                    return db.installBusinessObjectDef(obj);
+                }
+                else {
+                    return;
+                }
             }
             
             if(!versionRel.descendant) {
@@ -420,7 +427,7 @@ exports.importObject = function(className, obj, packageRef) {
         }
         
         if(className === 'BusinessObjectDef') {
-            return db.installBusinessObjectDef(obj)
+            return db.installBusinessObjectDef(obj);
         }
                 
         var updateVer = obj.__ver;

--- a/server/api/datasource/references.js
+++ b/server/api/datasource/references.js
@@ -388,6 +388,15 @@ exports.repair = function() {
           var handleRef = function(refTd, fieldVal, arrIndex) {
             var refId = fieldVal._id;
             var refClass = refTd.ref_class || fieldVal.ref_class; //ref_class can be defined in the field for non-specific references
+            if(!db[refClass]) {
+                console.log('found reference to nonexistant class %s -> %s', className, refClass);
+                var badRef = {
+                  bo:bo, field:refTd.field_name, refId:refId, arrIndex:arrIndex
+                };
+                //Clean these up later!
+                badRefs.push(badRef);
+                return Q(true);
+            }
             // console.log('handleRef %j', fieldVal);
             //Check if the reference is valid, if so update disp and denormalized fields
             return db[refClass].count({_id:refId}).exec().then(function(matchCount) {

--- a/server/api/datasource/version_id.js
+++ b/server/api/datasource/version_id.js
@@ -47,6 +47,69 @@ VersionId.prototype.increment = function() {
   }
 };
 
+VersionId.prototype.difference = function(otherVersionId) {
+    //Subtract each term in otherVersionId from this one
+    var diff = _.clone(this.instanceMap);
+    _.forEach(otherVersionId.instanceMap, function(val, key) {
+        diff[key] = (diff[key] || 0) - val;
+    });
+    return diff;
+};
+
+VersionId.prototype.relationshipTo = function(otherVersionId) {
+    //compute this - other
+    var diff = this.difference(otherVersionId);
+    
+    var hasNeg = false;
+    var hasPos = false;
+    
+    _.forEach(diff, function(val) {
+        if(val > 0) {
+            hasPos = true;
+        }
+        if(val < 0) {
+            hasNeg = true;
+        }
+    });
+    
+    return {
+        same:       (!hasPos && !hasNeg),   //all terms equal
+        descendant: (hasPos && !hasNeg),    //all terms larger in this
+        ancestor:   (!hasPos && hasNeg),    //all terms larger in other
+        cousin:     (hasPos && hasNeg)      //some terms larger, some smaller
+    };
+};
+
+VersionId.prototype.isDescendantOf = function(otherVersionId) {
+    var diff = this.difference(otherVersionId);
+    
+    var hasNeg = false;
+    var hasPos = false;
+    
+    _.forEach(diff, function(val) {
+        if(val > 0) {
+            hasPos = true;
+        }
+        if(val < 0) {
+            hasNeg = true;
+        }
+    });
+    return hasPos && !hasNeg;
+};
+
+VersionId.prototype.isAncestorOrSelf = function(otherVersionId) {
+    var diff = this.difference(otherVersionId);
+    
+    var hasPos = false;
+    
+    _.forEach(diff, function(val) {
+        if(val > 0) {
+            hasPos = true;
+        }
+    });
+    return !hasPos;
+};
+
 VersionId.prototype.toString = function() {
   var resultArr = [];
   _.forEach(this.instanceMap, function(counter, instance) {


### PR DESCRIPTION
We now have a better view into issues that may come up when installing a package:
Each incoming record's version ID is compared to the one currently in the system.  If it is potentially unsafe to install (local changes may be overwritten), it skips and instead installs a PackageConflict record, containing diff information.

TODO: refine the process of merging in local diffs:  e.g. button on the PackageConflict record to install a merged version - with an appropriately merged version id.